### PR TITLE
disable some ffmemless efects (pinephone workaround)

### DIFF
--- a/data/plugins.d/50-ffmemless.ini
+++ b/data/plugins.d/50-ffmemless.ini
@@ -20,7 +20,8 @@ system_effects_env = NGF_FFMEMLESS_SETTINGS
 
 
 # All effect names must be listed here, otherwise they don't get created
-supported_effects = touch;touch_weak;touch_strong;release;release_weak;release_strong;drag_start;drag_fail;drag_boundary_drag_end;short;strong;long;notice;message;attention;alarm;ringtone
+#supported_effects = touch;touch_weak;touch_strong;release;release_weak;release_strong;drag_start;drag_fail;drag_boundary_drag_end;short;strong;long;notice;message;attention;alarm;ringtone
+supported_effects = touch;release;drag_start;drag_fail;drag_boundary_drag_end;short;strong;long;notice;message;attention;alarm;ringtone
 
 # Setting up the effect parameters.
 # - The only mandatory parameter is _TYPE, if it's missing effect is not created


### PR DESCRIPTION
See https://github.com/sailfishos/ngfd/pull/3

I am still not sure if is good idea to disable some effects in config file or if there is some way to provide override config file.